### PR TITLE
Update pcrelate.R

### DIFF
--- a/pcrelate.R
+++ b/pcrelate.R
@@ -50,7 +50,7 @@ seqSetFilter(gds, variant.id = variant_id, sample.id = sample_id)
 seqData <- SeqVarData(gds)
 iterator <- SeqVarBlockIterator(seqData, verbose=FALSE,
                                 variantBlock = argv$variant_block)
-mypcrel <- pcrelate(iterator, pcs = mypcair$vectors[, seq(argv$n_pcs)],
+mypcrel <- pcrelate(iterator, pcs = mypcair$vectors[, seq(argv$n_pcs), drop = FALSE],
                     training.set = mypcair$unrels, sample.include = sample_id,
                     sample.block.size = argv$sample_block_size)
 


### PR DESCRIPTION
I found this is necessary if you want to use just one PC (probably not too common, but I needed to do for troubleshooting)
Note: It would also be great to have an option to include all pcs (because I think the total number differs):
Something like:
if(n_pcs == "all"){
  pcs = mypcair$vectors
  } else {
  pcs = mypcair$vectors[, seq(argv$n_pcs), drop = FALSE]
  }