### PR TITLE
Update fit_null_mod.R

### DIFF
--- a/fit_null_mod.R
+++ b/fit_null_mod.R
@@ -32,7 +32,7 @@ if (!is.na(argv$sample_id)) {
 }
 
 if (is.na(argv$covars[1])) {
-  covars <- NULL
+  argv$covars <- NULL
 }
 
 if (!is.na(argv$grm_file)) {


### PR DESCRIPTION
Otherwise, without covariates, fitnullmod will read the covariates argument as NA, which creates an error