### PR TITLE
Add RUTH wrapper and helper scripts

### DIFF
--- a/add_fid.R
+++ b/add_fid.R
@@ -1,0 +1,22 @@
+#! /usr/bin/env Rscript
+library(argparser)
+library(magrittr)
+
+argp <- arg_parser("Add FID to sample ID") %>%
+  add_argument("plink_prefix", help  = "Prefix for PLINK bed/bim/fam files") %>%
+  add_argument("sample_id", help = "Vector of sample IDs (.rds)") %>%
+  add_argument("--out_file", default = "sample_ids.txt", help = "output filename")
+argv <- parse_args(argp)
+
+sessionInfo()
+print(argv)
+
+library(dplyr)
+
+sample.id <- readRDS(argv$sample_id)
+fam_header <- c("FID", "IID", "FATHER", "MOTHER", "SEX", "PHENOTYPE")
+fam <- paste0(argv$plink_prefix, ".fam") %>% read.table(col.names = fam_header)
+
+fam_keep <- filter(fam, IID %in% sample.id) %>% select(FID, IID)
+write.table(fam_keep, argv$out_file, na = "", row.names = FALSE,
+            col.names = FALSE, quote = FALSE)

--- a/get_controls.R
+++ b/get_controls.R
@@ -5,7 +5,6 @@ library(magrittr)
 argp <- arg_parser("Get IDs of controls") %>%
   add_argument("pheno_file", help="Phenotype file in annotated dataframe format (.rds)") %>%
   add_argument("status", help = "Case/control status variable in pheno_file (binary)") %>%
-  add_argument("plink_prefix", help  = "Prefix for PLINK bed/bim/fam files") %>%
   add_argument("--out_prefix", help = "Prefix for output files",
                default = "") %>%
   add_argument("--sample_id", help = "File with vector of sample IDs to keep (.rds)")
@@ -17,8 +16,6 @@ print(argv)
 library(Biobase)
 library(dplyr)
 
-fam_header <- c("FID", "IID", "FATHER", "MOTHER", "SEX", "PHENOTYPE")
-fam <- paste0(argv$plink_prefix, ".fam") %>% read.table(col.names = fam_header)
 
 pheno <- readRDS(argv$pheno_file) %>% pData()
 controls <- filter(pheno, .data[[argv$status]] == 0)$sample.id
@@ -30,9 +27,5 @@ if (!is.na(argv$sample_id)) {
   keep <- controls
 }
 
-fam_keep <- filter(fam, IID %in% keep) %>% select(FID, IID)
-paste0(argv$out_prefix, "controls.txt") %>%
-  write.table(fam_keep, ., na = "", row.names = FALSE, col.names = FALSE,
-              quote = FALSE)
 
 paste0(argv$out_prefix, "controls.rds") %>% saveRDS(keep, .)

--- a/get_controls.R
+++ b/get_controls.R
@@ -5,8 +5,7 @@ library(magrittr)
 argp <- arg_parser("Get IDs of controls") %>%
   add_argument("pheno_file", help="Phenotype file in annotated dataframe format (.rds)") %>%
   add_argument("status", help = "Case/control status variable in pheno_file (binary)") %>%
-  add_argument("--out_prefix", help = "Prefix for output files",
-               default = "") %>%
+  add_argument("--out_file", help = "Output filename", default = "controls.rds") %>%
   add_argument("--sample_id", help = "File with vector of sample IDs to keep (.rds)")
 argv <- parse_args(argp)
 
@@ -27,5 +26,4 @@ if (!is.na(argv$sample_id)) {
   keep <- controls
 }
 
-
-paste0(argv$out_prefix, "controls.rds") %>% saveRDS(keep, .)
+saveRDS(keep, argv$out_file)

--- a/get_controls.R
+++ b/get_controls.R
@@ -1,0 +1,38 @@
+#! /usr/bin/env Rscript
+library(argparser)
+library(magrittr)
+
+argp <- arg_parser("Get IDs of controls") %>%
+  add_argument("pheno_file", help="Phenotype file in annotated dataframe format (.rds)") %>%
+  add_argument("status", help = "Case/control status variable in pheno_file (binary)") %>%
+  add_argument("plink_prefix", help  = "Prefix for PLINK bed/bim/fam files") %>%
+  add_argument("--out_prefix", help = "Prefix for output files",
+               default = "") %>%
+  add_argument("--sample_id", help = "File with vector of sample IDs to keep (.rds)")
+argv <- parse_args(argp)
+
+sessionInfo()
+print(argv)
+
+library(Biobase)
+library(dplyr)
+
+fam_header <- c("FID", "IID", "FATHER", "MOTHER", "SEX", "PHENOTYPE")
+fam <- paste0(argv$plink_prefix, ".fam") %>% read.table(col.names = fam_header)
+
+pheno <- readRDS(argv$pheno_file) %>% pData()
+controls <- filter(pheno, .data[[argv$status]] == 0)$sample.id
+
+if (!is.na(argv$sample_id)) {
+  sample_id <- readRDS(argv$sample_id)
+  keep <- controls[controls %in% sample_id]
+} else {
+  keep <- controls
+}
+
+fam_keep <- filter(fam, IID %in% keep) %>% select(FID, IID)
+paste0(argv$out_prefix, "controls.txt") %>%
+  write.table(fam_keep, ., na = "", row.names = FALSE, col.names = FALSE,
+              quote = FALSE)
+
+paste0(argv$out_prefix, "controls.rds") %>% saveRDS(keep, .)

--- a/parse_ruth.R
+++ b/parse_ruth.R
@@ -1,0 +1,28 @@
+#! /usr/bin/env Rscript
+library(argparser)
+library(magrittr)
+
+argp <- arg_parser("Parse RUTH output") %>%
+  add_argument("ruth_file", help = "RUTH output file (.vcf)") %>%
+  add_argument("--out_file", help = "Output filename (.rds)",
+               default = "ruth.rds")
+argv <- parse_args(argp)
+
+sessionInfo()
+print(argv)
+
+library(tidyr)
+library(dplyr)
+
+ruth_res <- read.table(argv$ruth_file, sep = "\t", comment.char = "#",
+                       na.strings = ".",
+                       col.names = c("CHROM", "POS", "ID", "REF", "ALT", "QUAL",
+                                     "FILTER", "INFO")) %>%
+  separate(INFO, sep = ";",
+           into = c("PR", "FIBC_P", "HWE_SLP_P", "FIBC_I", "HWE_SLP_I", "MAX_IF",
+                    "MIN_IF", "LLK0", "BETA_IF")) %>%
+  mutate(across(FIBC_P:BETA_IF, ~ sub("^.*=", "", .x))) %>%
+  separate(BETA_IF, paste0("BETA_IF_", 1:5), ",") %>%
+  mutate(across(FIBC_P:BETA_IF_5, as.numeric))
+
+saveRDS(ruth_res, argv$out_file)

--- a/parse_ruth.R
+++ b/parse_ruth.R
@@ -23,6 +23,6 @@ ruth_res <- read.table(argv$ruth_file, sep = "\t", comment.char = "#",
                     "MIN_IF", "LLK0", "BETA_IF")) %>%
   mutate(across(FIBC_P:BETA_IF, ~ sub("^.*=", "", .x))) %>%
   separate(BETA_IF, paste0("BETA_IF_", 1:5), ",") %>%
-  mutate(across(FIBC_P:BETA_IF_5, as.numeric))
+  mutate(across(FIBC_P:BETA_IF_5, as.numeric), ABS_PVAL = abs(HWE_SLP_I))
 
 saveRDS(ruth_res, argv$out_file)

--- a/run_ruth.sh
+++ b/run_ruth.sh
@@ -2,8 +2,9 @@
 
 # Set default args
 FIELD=GT
+CLEANUP=false
 
-while getopts ":p:d:P:o:g:D:k:v:s:n:f:N:" opt; do
+while getopts ":p:d:P:o:g:D:k:v:s:n:f:N:c" opt; do
   case ${opt} in
     p)
       PHENO_FILE=$OPTARG
@@ -41,6 +42,9 @@ while getopts ":p:d:P:o:g:D:k:v:s:n:f:N:" opt; do
     N)
       NUM_CORE=$OPTARG
       ;;
+    c)
+      CLEANUP=true
+      ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2
       exit 1
@@ -48,7 +52,7 @@ while getopts ":p:d:P:o:g:D:k:v:s:n:f:N:" opt; do
   esac
 done
 
-get_controls.R $PHENO_FILE $DX --out_prefix $OUT_PREF
+get_controls.R $PHENO_FILE $DX --out_file ${OUT_PREF}controls.rds
 
 pcair.R $GDS_FILE $DIV_OBJ $KIN_OBJ --variant_id $VARIANT_ID \
   --sample_id ${OUT_PREF}controls.rds --num_core $NUM_CORE --out_prefix $OUT_PREF
@@ -65,4 +69,7 @@ ruth --vcf ${OUT_PREF}unrel_controls.vcf.gz --evec ${OUT_PREF}ruth_pcs.txt --out
 
 parse_ruth.R ${OUT_PREF}ruth.vcf --out_file ${OUT_PREF}ruth.rds
 
-
+if [ "$CLEANUP" = true ] ; then
+  rm ${OUT_PREF}controls.rds ${OUT_PREF}unrel_controls* \
+    ${OUT_PREF}ruth_pcs.txt ${OUT_PREF}ruth.vcf ${OUT_PREF}pcair*
+fi

--- a/run_ruth.sh
+++ b/run_ruth.sh
@@ -8,46 +8,59 @@ HELP=false
 while getopts ":p:d:P:o:g:D:k:v:s:n:f:N:ch" opt; do
   case ${opt} in
     p)
+      # Path to phenotype ADF in .rds format
       PHENO_FILE=$OPTARG
       ;;
     d)
+      # Name of DX variable in PHENO_FILE. Coded as 0/1.
       DX=$OPTARG
       ;;
     P)
+      # Path to PLINK .bim/.bam/.fam files (prefix only)
       PLINK_PREF=$OPTARG
       ;;
     o)
+      # Characters to prepend to output files
       OUT_PREF=$OPTARG
       ;;
     g)
+      # Path to GDS file
       GDS_FILE=$OPTARG
       ;;
     D)
+      # divobj for PC-AiR (.rds)
       DIV_OBJ=$OPTARG
       ;;
     k)
+      # kinobj for PC-AiR (.rds) 
       KIN_OBJ=$OPTARG
       ;;
     v)
+      # Vector of variant IDs to include (.rds)
       VARIANT_ID=$OPTARG
       ;;
-    s)
-      SAMPLE_ID=$OPTARG
-      ;;
     n)
+      # Number of PCs to include fo PC-AiR
       N_PC=$OPTARG
       ;;
     f)
+      # -GT option for RUTH
       FIELD=$OPTARG
       ;;
     N)
+      # Number of cores to use where it is an option.
       NUM_CORE=$OPTARG
       ;;
     c)
+      # Flag to delete intermediate files.
       CLEANUP=true
       ;;
     h)
-      HELP=true
+      # Flag to print the following message:
+      echo "\
+        This script uses the bash utility getopts to parse command line
+        options. For argument descriptions, check the \`while getopts\` section at 
+        the head of run_ruth.sh"
       ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2
@@ -56,12 +69,6 @@ while getopts ":p:d:P:o:g:D:k:v:s:n:f:N:ch" opt; do
   esac
 done
 
-if [ "$HELP" = true ] ; then
-  echo "\
-    This script uses the bash utility getopts to parse command line
-    options. For argument descriptions, check the \`while getopts\` section at 
-    the head of run_ruth.sh"
-fi
 get_controls.R $PHENO_FILE $DX --out_file ${OUT_PREF}controls.rds
 
 pcair.R $GDS_FILE $DIV_OBJ $KIN_OBJ --variant_id $VARIANT_ID \

--- a/run_ruth.sh
+++ b/run_ruth.sh
@@ -3,8 +3,9 @@
 # Set default args
 FIELD=GT
 CLEANUP=false
+HELP=false
 
-while getopts ":p:d:P:o:g:D:k:v:s:n:f:N:c" opt; do
+while getopts ":p:d:P:o:g:D:k:v:s:n:f:N:ch" opt; do
   case ${opt} in
     p)
       PHENO_FILE=$OPTARG
@@ -45,6 +46,9 @@ while getopts ":p:d:P:o:g:D:k:v:s:n:f:N:c" opt; do
     c)
       CLEANUP=true
       ;;
+    h)
+      HELP=true
+      ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2
       exit 1
@@ -52,6 +56,12 @@ while getopts ":p:d:P:o:g:D:k:v:s:n:f:N:c" opt; do
   esac
 done
 
+if [ "$HELP" = true ] ; then
+  echo "\
+    This script uses the bash utility getopts to parse command line
+    options. For argument descriptions, check the \`while getopts\` section at 
+    the head of run_ruth.sh"
+fi
 get_controls.R $PHENO_FILE $DX --out_file ${OUT_PREF}controls.rds
 
 pcair.R $GDS_FILE $DIV_OBJ $KIN_OBJ --variant_id $VARIANT_ID \

--- a/run_ruth.sh
+++ b/run_ruth.sh
@@ -1,0 +1,65 @@
+#! /usr/bin/env bash
+
+# Set default args
+FIELD=GT
+
+while getopts ":p:d:P:o:g:D:k:v:s:n:f:" opt; do
+  case ${opt} in
+    p)
+      PHENO_FILE=$OPTARG
+      ;;
+    d)
+      DX=$OPTARG
+      ;;
+    P)
+      PLINK_PREF=$OPTARG
+      ;;
+    o)
+      OUT_PREF=$OPTARG
+      ;;
+    g)
+      GDS_FILE=$OPTARG
+      ;;
+    D)
+      DIV_OBJ=$OPTARG
+      ;;
+    k)
+      KIN_OBJ=$OPTARG
+      ;;
+    v)
+      VARIANT_ID=$OPTARG
+      ;;
+    s)
+      SAMPLE_ID=$OPTARG
+      ;;
+    n)
+      NUM_CORE=$OPTARG
+      ;;
+    f)
+      FIELD=$OPTARG
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+  esac
+done
+
+get_controls.R $PHENO_FILE $DX --out_prefix $OUT_PREF
+
+pcair.R $GDS_FILE $DIV_OBJ $KIN_OBJ --variant_id $VARIANT_ID \
+  --sample_id ${OUT_PREF}controls.rds --num_core $NUM_CORE --out_prefix $OUT_PREF
+
+add_fid.R $PLINK_PREF ${OUT_PREF}pcair_unrels.rds --out_file ${OUT_PREF}unrel_controls.txt
+
+plink --recode vcf bgz \
+  --bfile $PLINK_PREF --keep ${OUT_PREF}unrel_controls.txt --out ${OUT_PREF}unrel_controls
+
+ruth_format_pcs.R ${OUT_PREF}pcair_pcs.rds ${OUT_PREF}unrel_controls.txt --out_file ${OUT_PREF}ruth_pcs.txt
+
+ruth --vcf ${OUT_PREF}unrel_controls.vcf.gz --evec ${OUT_PREF}ruth_pcs.txt --out ${OUT_PREF}ruth.vcf \
+  --field $FIELD --site-only
+
+parse_ruth.R ${OUT_PREF}ruth.vcf --out_file ${OUT_PREF}ruth.rds
+
+

--- a/run_ruth.sh
+++ b/run_ruth.sh
@@ -3,7 +3,7 @@
 # Set default args
 FIELD=GT
 
-while getopts ":p:d:P:o:g:D:k:v:s:n:f:" opt; do
+while getopts ":p:d:P:o:g:D:k:v:s:n:f:N:" opt; do
   case ${opt} in
     p)
       PHENO_FILE=$OPTARG
@@ -33,10 +33,13 @@ while getopts ":p:d:P:o:g:D:k:v:s:n:f:" opt; do
       SAMPLE_ID=$OPTARG
       ;;
     n)
-      NUM_CORE=$OPTARG
+      N_PC=$OPTARG
       ;;
     f)
       FIELD=$OPTARG
+      ;;
+    N)
+      NUM_CORE=$OPTARG
       ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2
@@ -58,7 +61,7 @@ plink --recode vcf bgz \
 ruth_format_pcs.R ${OUT_PREF}pcair_pcs.rds ${OUT_PREF}unrel_controls.txt --out_file ${OUT_PREF}ruth_pcs.txt
 
 ruth --vcf ${OUT_PREF}unrel_controls.vcf.gz --evec ${OUT_PREF}ruth_pcs.txt --out ${OUT_PREF}ruth.vcf \
-  --field $FIELD --site-only
+  --field $FIELD --site-only --num-pc $N_PC
 
 parse_ruth.R ${OUT_PREF}ruth.vcf --out_file ${OUT_PREF}ruth.rds
 

--- a/ruth_format_pcs.R
+++ b/ruth_format_pcs.R
@@ -3,7 +3,7 @@ library(argparser)
 library(magrittr)
 
 argp <- arg_parser("Format PC-AiR PCs for RUTH") %>%
-  add_argument("pcair_file", help = "File with pcair object (.rds)") %>%
+  add_argument("pc_file", help = "File with pcair PCs object (.rds)") %>%
   add_argument("fam_file", help = "PLINK .fam file. Can be partial version from get_controls.R") %>%
   add_argument("--out_file", help = "Name for output file",
                default = "ruth_pcs.txt")
@@ -17,8 +17,9 @@ library(dplyr)
 fam <- read.table(argv$fam_file)[,1:2] %>%
   set_colnames(c("FID", "SAMPLE_ID"))
 
-pcair <- readRDS(argv$pcair_file)
-pcs <- as.data.frame(pcair$vectors) %>%
+pcair <- readRDS(argv$pc_file)
+pcs <- readRDS(argv$pc_file) %>%
+  as.data.frame() %>%
   # variable names must be SAMPLE_ID, PC1, PC2, ....
   rename_with(~ gsub("V", "PC", .x)) %>%
   mutate(SAMPLE_ID = rownames(.)) %>%

--- a/ruth_format_pcs.R
+++ b/ruth_format_pcs.R
@@ -1,0 +1,30 @@
+#! /usr/bin/env Rscript
+library(argparser)
+library(magrittr)
+
+argp <- arg_parser("Format PC-AiR PCs for RUTH") %>%
+  add_argument("pcair_file", help = "File with pcair object (.rds)") %>%
+  add_argument("fam_file", help = "PLINK .fam file. Can be partial version from get_controls.R") %>%
+  add_argument("--out_file", help = "Name for output file",
+               default = "ruth_pcs.txt")
+argv <- parse_args(argp)
+
+sessionInfo()
+print(argv)
+
+library(dplyr)
+
+fam <- read.table(argv$fam_file)[,1:2] %>%
+  set_colnames(c("FID", "SAMPLE_ID"))
+
+pcair <- readRDS(argv$pcair_file)
+pcs <- as.data.frame(pcair$vectors) %>%
+  # variable names must be SAMPLE_ID, PC1, PC2, ....
+  rename_with(~ gsub("V", "PC", .x)) %>%
+  mutate(SAMPLE_ID = rownames(.)) %>%
+  left_join(fam, by = "SAMPLE_ID") %>%
+  # RUTH requires the ID field to be a concatenation of FID and IID
+  mutate(SAMPLE_ID = paste(FID, SAMPLE_ID, sep = "_")) %>%
+  select(SAMPLE_ID, matches("PC"))
+write.table(pcs, argv$out_file, sep = "\t", na = "", row.names = FALSE,
+            quote = FALSE)


### PR DESCRIPTION
Add wrapper script to:

1) Get vector of controls
1) Run PC-AiR
1) Create a VCF of just unrelated controls
1) Format PCs into the required format for RUTH
1) Run RUTH
1) Parse RUTH output and save in .rds format

R helper scripts have automatically generated help pages with the R package argparser. See the comments at the head of run_ruth.sh for argument descriptions.

Example usage:
```
run_ruth.sh -p /nfs/beluga0_home/ANALYSIS/NIAGADS/NG00022/pheno/pheno_adf.rds \
  -d Case_Control \
  -o tmp/ \
  -g /nfs/beluga0_home/ANALYSIS/NIAGADS/NG00022/ADC1_clean_2018_1012.gds \
  -D /nfs/beluga0_home/ANALYSIS/NIAGADS/NG00022/pcs_grm_pheno_only/out/a_pcr_mat.rds \
  -k /nfs/beluga0_home/ANALYSIS/NIAGADS/NG00022/pcs_grm_pheno_only/out/king_grm.rds \
  -v /nfs/beluga0_home/ANALYSIS/NIAGADS/NG00022/pcs_grm_pheno_only/out/pruned_snps.rds \
  -n 4 \
  -N 12 \
  -P /nfs/beluga0_home/DATA/NIAGADS/NG00022/ADC1_clean_2018_1012 \
  -h
```
